### PR TITLE
Setup authorization middleware identifying an admin user

### DIFF
--- a/src/handlers/user.ts
+++ b/src/handlers/user.ts
@@ -63,9 +63,9 @@ export class User extends BaseHandler {
                 if (user) {
                     const payload = {
                         _id: user._id,
-                        firstName: user.firstName,
-                        lastName: user.lastName,
-                        email: user.email
+                        username: user.username,
+                        email: user.email,
+                        isAdmin: user.isAdmin,
                     };
 
                     if (!bcrypt.compareSync(password, user.hash)) {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,9 +1,10 @@
 import jwt from 'jsonwebtoken';
 import { Request, Response, NextFunction} from 'express';
+import { getToken } from './utils'
 
 const jwtSecretKey = process.env.SECRET as string
 
-const protect = async (req: Request, res: Response, next: NextFunction) => {
+export const protect = async (req: Request, res: Response, next: NextFunction) => {
   // get the token
   try {
     const token = req.headers.authorization? req.headers.authorization.split(' ')[1] : null;
@@ -25,4 +26,21 @@ const protect = async (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
-export default protect
+export interface IToken {
+  isAdmin: boolean;
+}
+
+export const authorizeAdmin = async (req: Request, res: Response, next: NextFunction) => {
+  const token = getToken(req)
+  try {
+      jwt.verify(token, jwtSecretKey, (err, decoded) => {
+          if ( (decoded && (decoded as IToken).isAdmin === true) ) {
+              return next() 
+          } else {
+              return res.status(403).send({ message: 'Forbidden! Only an admin can perform this action' }) 
+          }
+      })
+  } catch (err) {
+      return res.send(err)
+  }
+}

--- a/src/middleware/utils.ts
+++ b/src/middleware/utils.ts
@@ -9,3 +9,7 @@ export const cors = (_req: Request, res: Response, next: NextFunction) => {
   return next();
 };
 
+export const getToken = (req: Request) => {
+  const token = req.headers.authorization
+  return token ? token.split(' ')[1] : ''
+}

--- a/src/routes/story.routes.ts
+++ b/src/routes/story.routes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { StoryLookUp } from '../handlers/story';
-import protect from '../middleware/auth';
+import { protect } from '../middleware/auth';
 
 const router = express.Router();
 

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { User } from '../handlers/user';
 import { validateSignin, validateSignup } from '../middleware/validate';
+import { authorizeAdmin } from '../middleware/auth';
 
 const router = express.Router();
 


### PR DESCRIPTION
* Set up middleware to accurately identify admin users, and ensure regular users do not have admin privileges.

_Usage_
For instance, only admin users can delete a user.
Simply inject the middleware - `authorizeAdmin`, as shown below;

```
router
    .route('/:id')
    .delete(authorizeAdmin, User.DeleteAUser)
```