### PR TITLE
Update signup payload to allow first and last name

### DIFF
--- a/src/handlers/user.ts
+++ b/src/handlers/user.ts
@@ -13,7 +13,7 @@ export class User extends BaseHandler {
       if (!isEmail(req.body.email)) {
         return res.status(400).send({ message: 'Email Invalid' });
       } else {
-        const { email, username, password } = req.body;
+        const { email, username, firstName, lastName, password } = req.body;
 
         if (password.length < 7) {
           return res
@@ -29,6 +29,8 @@ export class User extends BaseHandler {
           } else {
             return UserModel.create({
               username: username,
+              firstName: firstName,
+              lastName: lastName,
               email: email,
               hash: bcrypt.hashSync(password, 10)
             }).then((user) => {
@@ -64,6 +66,8 @@ export class User extends BaseHandler {
           const payload = {
             _id: user._id,
             username: user.username,
+            firstName: user.firstName,
+            lastName: user.lastName,
             email: user.email,
             isAdmin: user.isAdmin
           };
@@ -169,7 +173,7 @@ export class User extends BaseHandler {
 
     try {
         const userId = req.params.id
-        const { username, email, isAdmin } = req.body
+        const { username, firstName, lastName, email, isAdmin } = req.body
 
         if (Types.ObjectId.isValid(userId)) {
 
@@ -179,6 +183,8 @@ export class User extends BaseHandler {
                 if (document) {
                     document.username = username || document.username
                     document.email = email || document.email
+                    document.firstName = firstName || document.firstName
+                    document.lastName = lastName || document.lastName
                     document.isAdmin = isAdmin || document.isAdmin
 
                     document.save().then(async (user: IUser) => {

--- a/src/model/user.model.ts
+++ b/src/model/user.model.ts
@@ -5,6 +5,12 @@ const userSchema = new Schema<IUser>({
     username: {
         type: String
     },
+    firstName: {
+        type: String
+    },
+    lastName: {
+        type: String
+    },
     email: {
         type: String,
         required: [true, 'Email is required'],

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -2,6 +2,8 @@ import Joi from 'joi';
 
 export const signupSchema = Joi.object({
     username: Joi.string().required(),
+    firstName: Joi.string().required(),
+    lastName: Joi.string().required(),
     email: Joi.string().email().required(),
     password: Joi.string().min(6).required()
 });


### PR DESCRIPTION
* Users are now required to provide first name and last name on signup

signup payload 
```
{
    username: string,
    firstName: string,
    lastName: string,
    email: string,
    password: string

}
```